### PR TITLE
Upgrade offline store to support feast>=0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It can be installed from pip and configured in the `feature_store.yaml` configur
 We strongly encourage you to contribute to our repository. Find out more in our [contribution guidelines](https://github.com/Adyen/.github/blob/master/CONTRIBUTING.md)
 
 ## Requirements
-Currently only supports Feast version `0.14.1`.
+Currently only supports Feast versions `>=0.15.0`.
 
 ## Installation
 `pip install feast-spark-offline-store` 

--- a/feast_spark_offline_store/spark.py
+++ b/feast_spark_offline_store/spark.py
@@ -133,6 +133,7 @@ class SparkOfflineStore(OfflineStore):
             query_context,
             left_table_query_string=table_name,
             entity_df_event_timestamp_col=entity_df_event_timestamp_col,
+            entity_df_columns=entity_schema.keys(),
             query_template=MULTIPLE_FEATURE_VIEW_POINT_IN_TIME_JOIN,
             full_feature_names=full_feature_names,
         )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 from setuptools import find_packages
 
 INSTALL_REQUIRES = [
-    "feast==0.14.1",
+    "feast>=0.15.0",
     "pyspark>=3.0",
     "pyarrow>=1.0.0",
     "numpy",


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
Upgrade feast version to `>=0.15.0`. 

## Tested scenarios
Tested for both `feast==0.15.0` and `feast==0.16.1`.

**Fixed issue**:  Not reported.