### PR TITLE
Make SparkOfflineStore compatible with interface change in feast>=0.17

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jbvaningen @thijsbrits @joostrothweiler
+* @jbvaningen @thijsbrits

--- a/example_feature_repo/example.py
+++ b/example_feature_repo/example.py
@@ -18,8 +18,7 @@ from feast_spark_offline_store import SparkSource
 spark = SparkSession.builder.getOrCreate()
 
 # Create some temp tables, normally these would registered hive tables
-
-end_date = datetime.now(tz="UTC").replace(microsecond=0, second=0, minute=0)
+end_date = datetime.now().replace(microsecond=0, second=0, minute=0)
 start_date = end_date - timedelta(days=15)
 
 driver_entities = [1001, 1002, 1003, 1004, 1005]

--- a/example_feature_repo/example.py
+++ b/example_feature_repo/example.py
@@ -1,48 +1,64 @@
-# This is an example feature definition file
+# # # # # # # # # # # # # # # # # # # # # # # #
+#  This is an example feature definition file #
+# # # # # # # # # # # # # # # # # # # # # # # #
 
-from google.protobuf.duration_pb2 import Duration
+from datetime import datetime, timedelta
 
 from feast import Entity, Feature, FeatureView, ValueType
-from feast_spark_offline_store import SparkSource
-from pyspark.sql import SparkSession
-from datetime import datetime, timedelta
 from feast.driver_test_data import (
     create_driver_hourly_stats_df,
     create_customer_daily_profile_df,
 )
+from google.protobuf.duration_pb2 import Duration
+from pyspark.sql import SparkSession
 
-# # we are loading a sparksession here, but should be configurable in the yaml
+from feast_spark_offline_store import SparkSource
+
+# We are loading a spark session here, but should be configurable in the yaml
 spark = SparkSession.builder.getOrCreate()
 
-end_date = datetime.now().replace(microsecond=0, second=0, minute=0)
+# Create some temp tables, normally these would registered hive tables
+
+end_date = datetime.now(tz="UTC").replace(microsecond=0, second=0, minute=0)
 start_date = end_date - timedelta(days=15)
 
 driver_entities = [1001, 1002, 1003, 1004, 1005]
 driver_df = create_driver_hourly_stats_df(driver_entities, start_date, end_date)
-
-
-# this would just be a registered table
 spark.createDataFrame(driver_df).createOrReplaceTempView("driver_stats")
-# ####
 
+customer_entities = [201, 202, 203, 204, 205]
+customer_df = create_customer_daily_profile_df(customer_entities, start_date, end_date)
+spark.createDataFrame(customer_df).createOrReplaceTempView("customer_daily_stats")
+
+# Next we can define the spark sources, the table name has to match the tmp views
 driver_hourly_stats = SparkSource(
     table="driver_stats",  # must be serializable so no support of DataFrame objects
     event_timestamp_column="event_timestamp",
     created_timestamp_column="created",
 )
+customer_daily_stats = SparkSource(
+    table="customer_daily_stats",  # must be serializable so no support of DataFrame objects
+    event_timestamp_column="event_timestamp",
+    created_timestamp_column="created",
+)
 
-# Define an entity for the driver.
+# Entity definitions
 driver = Entity(
     name="driver_id",
     value_type=ValueType.INT64,
     description="driver id",
 )
+customer = Entity(
+    name="customer_id",
+    value_type=ValueType.INT64,
+    description="customer id",
+)
 
-# Define FeatureView
+# Finally the feature views link everything together
 driver_hourly_stats_view = FeatureView(
     name="driver_hourly_stats",
     entities=["driver_id"],
-    ttl=Duration(seconds=86400 * 1),
+    ttl=Duration(seconds=86400 * 7),  # one week
     features=[
         Feature(name="conv_rate", dtype=ValueType.FLOAT),
         Feature(name="acc_rate", dtype=ValueType.FLOAT),
@@ -52,29 +68,10 @@ driver_hourly_stats_view = FeatureView(
     batch_source=driver_hourly_stats,
     tags={},
 )
-
-
-customer_entities = [201, 202, 203, 204, 205]
-customer_df = create_customer_daily_profile_df(customer_entities, start_date, end_date)
-spark.createDataFrame(customer_df).createOrReplaceTempView("customer_daily_stats")
-
-customer_daily_stats = SparkSource(
-    table="customer_daily_stats",  # must be serializable so no support of DataFrame objects
-    event_timestamp_column="event_timestamp",
-    created_timestamp_column="created",
-)
-
-customer = Entity(
-    name="customer_id",
-    value_type=ValueType.INT64,
-    description="customer id",
-)
-
-# Define FeatureView
 customer_daily_profile_view = FeatureView(
     name="customer_daily_profile",
     entities=["customer_id"],
-    ttl=Duration(seconds=86400 * 1),
+    ttl=Duration(seconds=86400 * 7),  # one week
     features=[
         Feature(name="current_balance", dtype=ValueType.FLOAT),
         Feature(name="avg_passenger_count", dtype=ValueType.FLOAT),

--- a/example_feature_repo/example.py
+++ b/example_feature_repo/example.py
@@ -6,7 +6,10 @@ from feast import Entity, Feature, FeatureView, ValueType
 from feast_spark_offline_store import SparkSource
 from pyspark.sql import SparkSession
 from datetime import datetime, timedelta
-from feast.driver_test_data import create_driver_hourly_stats_df, create_customer_daily_profile_df
+from feast.driver_test_data import (
+    create_driver_hourly_stats_df,
+    create_customer_daily_profile_df,
+)
 
 # # we are loading a sparksession here, but should be configurable in the yaml
 spark = SparkSession.builder.getOrCreate()
@@ -81,4 +84,3 @@ customer_daily_profile_view = FeatureView(
     batch_source=customer_daily_stats,
     tags={},
 )
-

--- a/example_feature_repo/feature_store.yaml
+++ b/example_feature_repo/feature_store.yaml
@@ -10,5 +10,6 @@ offline_store:
         spark.sql.catalogImplementation: "hive"
         spark.sql.parser.quotedRegexColumnNames: "true"
         spark.sql.session.timeZone: "UTC"
-
-##        # etc: etc....
+online_store:
+    path: data/online_store.db
+## etc: etc....

--- a/feast_spark_offline_store/spark.py
+++ b/feast_spark_offline_store/spark.py
@@ -116,9 +116,7 @@ class SparkOfflineStore(OfflineStore):
             entity_schema=entity_schema,
         )
         expected_join_keys = offline_utils.get_expected_join_keys(
-            project=project,
-            feature_views=feature_views,
-            registry=registry
+            project=project, feature_views=feature_views, registry=registry
         )
         offline_utils.assert_expected_columns_in_entity_df(
             entity_schema=entity_schema,
@@ -133,7 +131,7 @@ class SparkOfflineStore(OfflineStore):
             spark_session=spark_session,
             table_name=tmp_entity_df_table_name,
             project=project,
-            registry=registry
+            registry=registry,
         )
         query = offline_utils.build_point_in_time_query(
             feature_view_query_contexts=query_context,
@@ -144,9 +142,7 @@ class SparkOfflineStore(OfflineStore):
             full_feature_names=full_feature_names,
         )
         on_demand_feature_views = OnDemandFeatureView.get_requested_odfvs(
-            feature_refs=feature_refs,
-            project=project,
-            registry=registry
+            feature_refs=feature_refs, project=project, registry=registry
         )
 
         return SparkRetrievalJob(
@@ -164,7 +160,7 @@ class SparkOfflineStore(OfflineStore):
         feature_name_columns: List[str],
         event_timestamp_column: str,
         start_date: datetime,
-        end_date: datetime
+        end_date: datetime,
     ) -> RetrievalJob:
         pass
 
@@ -289,7 +285,9 @@ def _get_entity_df_event_timestamp_range(
             FROM {table_name}
             """
         ).collect()
-        assert len(result) == 1, "Could not extract event timestamp range, perhaps entity_df is empty?"
+        assert (
+            len(result) == 1
+        ), "Could not extract event timestamp range, perhaps entity_df is empty?"
         entity_df_event_timestamp_range = (
             result[0]["min"],
             result[0]["max"],
@@ -323,9 +321,7 @@ def _get_feature_view_query_context(
     project: str,
 ) -> List[FeatureViewQueryContext]:
     # interface of offline_utils.get_feature_view_query_context changed in feast==0.17
-    arg_spec = inspect.getfullargspec(
-        func=offline_utils.get_feature_view_query_context
-    )
+    arg_spec = inspect.getfullargspec(func=offline_utils.get_feature_view_query_context)
     if "entity_df_timestamp_range" in arg_spec.args:
         # for feast>=0.17
         entity_df_timestamp_range = _get_entity_df_event_timestamp_range(

--- a/feast_spark_offline_store/spark.py
+++ b/feast_spark_offline_store/spark.py
@@ -1,24 +1,26 @@
-from typing import List, Union, Optional, Dict
-from pydantic import StrictStr
+import inspect
 from datetime import datetime
+from typing import List, Union, Optional, Dict, Tuple
 
-import pandas
-import pyspark
-import pyarrow
 import numpy as np
+import pandas
 import pandas as pd
+import pyarrow
+import pyspark
+from pydantic import StrictStr
+from pyspark import SparkConf
+from pyspark.sql import SparkSession
 from pytz import utc
 
-from feast.registry import Registry
 from feast import FeatureView, OnDemandFeatureView
 from feast.data_source import DataSource
-from feast.repo_config import FeastConfigBaseModel, RepoConfig
-from feast.infra.offline_stores.offline_store import OfflineStore, RetrievalJob
-from feast.infra.offline_stores import offline_utils
 from feast.errors import InvalidEntityType
+from feast.infra.offline_stores import offline_utils
+from feast.infra.offline_stores.offline_store import OfflineStore, RetrievalJob
+from feast.infra.offline_stores.offline_utils import FeatureViewQueryContext
+from feast.registry import Registry
+from feast.repo_config import FeastConfigBaseModel, RepoConfig
 
-from pyspark.sql import SparkSession
-from pyspark import SparkConf
 from feast_spark_offline_store.spark_source import SparkSource
 from feast_spark_offline_store.spark_type_map import spark_schema_to_np_dtypes
 
@@ -101,51 +103,70 @@ class SparkOfflineStore(OfflineStore):
         assert isinstance(config.offline_store, SparkOfflineStoreConfig)
 
         spark_session = get_spark_session_or_start_new_with_repoconfig(
-            config.offline_store
+            store_config=config.offline_store
         )
-
-        table_name = offline_utils.get_temp_entity_table_name()
+        tmp_entity_df_table_name = offline_utils.get_temp_entity_table_name()
 
         entity_schema = _upload_entity_df_and_get_entity_schema(
-            spark_session, table_name, entity_df
+            spark_session=spark_session,
+            table_name=tmp_entity_df_table_name,
+            entity_df=entity_df,
         )
-
-        entity_df_event_timestamp_col = (
-            offline_utils.infer_event_timestamp_from_entity_df(entity_schema)
+        event_timestamp_col = offline_utils.infer_event_timestamp_from_entity_df(
+            entity_schema=entity_schema,
         )
-
         expected_join_keys = offline_utils.get_expected_join_keys(
-            project, feature_views, registry
+            project=project,
+            feature_views=feature_views,
+            registry=registry
         )
-
         offline_utils.assert_expected_columns_in_entity_df(
-            entity_schema, expected_join_keys, entity_df_event_timestamp_col
+            entity_schema=entity_schema,
+            join_keys=expected_join_keys,
+            entity_df_event_timestamp_col=event_timestamp_col,
         )
-
-        query_context = offline_utils.get_feature_view_query_context(
-            feature_refs,
-            feature_views,
-            registry,
-            project,
+        query_context = _get_feature_view_query_context(
+            entity_df=entity_df,
+            entity_df_event_timestamp_col=event_timestamp_col,
+            feature_refs=feature_refs,
+            feature_views=feature_views,
+            spark_session=spark_session,
+            table_name=tmp_entity_df_table_name,
+            project=project,
+            registry=registry
         )
-
         query = offline_utils.build_point_in_time_query(
-            query_context,
-            left_table_query_string=table_name,
-            entity_df_event_timestamp_col=entity_df_event_timestamp_col,
+            feature_view_query_contexts=query_context,
+            left_table_query_string=tmp_entity_df_table_name,
+            entity_df_event_timestamp_col=event_timestamp_col,
             entity_df_columns=entity_schema.keys(),
             query_template=MULTIPLE_FEATURE_VIEW_POINT_IN_TIME_JOIN,
             full_feature_names=full_feature_names,
+        )
+        on_demand_feature_views = OnDemandFeatureView.get_requested_odfvs(
+            feature_refs=feature_refs,
+            project=project,
+            registry=registry
         )
 
         return SparkRetrievalJob(
             spark_session=spark_session,
             query=query,
             full_feature_names=full_feature_names,
-            on_demand_feature_views=OnDemandFeatureView.get_requested_odfvs(
-                feature_refs, project, registry
-            ),
+            on_demand_feature_views=on_demand_feature_views,
         )
+
+    @staticmethod
+    def pull_all_from_table_or_query(
+        config: RepoConfig,
+        data_source: DataSource,
+        join_key_columns: List[str],
+        feature_name_columns: List[str],
+        event_timestamp_column: str,
+        start_date: datetime,
+        end_date: datetime
+    ) -> RetrievalJob:
+        pass
 
 
 # TODO fix internal abstract methods _to_df_internal _to_arrow_internal
@@ -193,26 +214,12 @@ class SparkRetrievalJob(RetrievalJob):
         df = self.to_df()
         return pyarrow.Table.from_pandas(df)  # noqa
 
+    def persist(self, storage):  # omitted type for feast>0.17 backwards compatibility
+        pass
 
-def _upload_entity_df_and_get_entity_schema(
-    spark_session, table_name, entity_df
-) -> Dict[str, np.dtype]:
-    if isinstance(entity_df, pd.DataFrame):
-        spark_session.createDataFrame(entity_df).createOrReplaceTempView(table_name)
-        return dict(zip(entity_df.columns, entity_df.dtypes))
-    elif isinstance(entity_df, str):
-        spark_session.sql(entity_df).createOrReplaceTempView(table_name)
-        limited_entity_df = spark_session.table(table_name)
-        # limited_entity_df = spark_session.table(table_name).limit(1).toPandas()
-
-        return dict(
-            zip(
-                limited_entity_df.columns,
-                spark_schema_to_np_dtypes(limited_entity_df.dtypes),
-            )
-        )
-    else:
-        raise InvalidEntityType(type(entity_df))
+    @property
+    def metadata(self):  # omitted type for feast>0.17 backwards compatibility
+        pass
 
 
 def get_spark_session_or_start_new_with_repoconfig(
@@ -238,12 +245,111 @@ def get_spark_session_or_start_new_with_repoconfig(
     return spark_session
 
 
+def _upload_entity_df_and_get_entity_schema(
+    spark_session: SparkSession,
+    table_name: str,
+    entity_df: Union[pandas.DataFrame, str],
+) -> Dict[str, np.dtype]:
+    if isinstance(entity_df, pd.DataFrame):
+        spark_session.createDataFrame(entity_df).createOrReplaceTempView(table_name)
+        return dict(zip(entity_df.columns, entity_df.dtypes))
+    elif isinstance(entity_df, str):
+        spark_session.sql(entity_df).createOrReplaceTempView(table_name)
+        limited_entity_df = spark_session.table(table_name)
+        return dict(
+            zip(
+                limited_entity_df.columns,
+                spark_schema_to_np_dtypes(limited_entity_df.dtypes),
+            )
+        )
+    else:
+        raise InvalidEntityType(type(entity_df))
+
+
 def _format_datetime(t: datetime):
     # Since Hive does not support timezone, need to transform to utc.
     if t.tzinfo:
         t = t.astimezone(tz=utc)
     t = t.strftime("%Y-%m-%d %H:%M:%S.%f")
     return t
+
+
+def _get_entity_df_event_timestamp_range(
+    entity_df: Union[pd.DataFrame, str],
+    entity_df_event_timestamp_col: str,
+    spark_session: SparkSession,
+    table_name: str,
+) -> Tuple[datetime, datetime]:
+    if type(entity_df) is str:
+        result = spark_session.sql(
+            f"""
+            SELECT 
+                MIN({entity_df_event_timestamp_col}) AS min, 
+                MAX({entity_df_event_timestamp_col}) AS max 
+            FROM {table_name}
+            """
+        ).collect()
+        assert len(result) == 1, "Could not extract event timestamp range, perhaps entity_df is empty?"
+        entity_df_event_timestamp_range = (
+            result[0]["min"],
+            result[0]["max"],
+        )
+    elif isinstance(entity_df, pd.DataFrame):
+        entity_df_event_timestamp = entity_df.loc[
+            :, entity_df_event_timestamp_col
+        ].infer_objects()
+        if pd.api.types.is_string_dtype(entity_df_event_timestamp):
+            entity_df_event_timestamp = pd.to_datetime(
+                entity_df_event_timestamp, utc=True
+            )
+        entity_df_event_timestamp_range = (
+            entity_df_event_timestamp.min(),
+            entity_df_event_timestamp.max(),
+        )
+    else:
+        raise InvalidEntityType(type(entity_df))
+
+    return entity_df_event_timestamp_range
+
+
+def _get_feature_view_query_context(
+    entity_df: Union[pd.DataFrame, str],
+    entity_df_event_timestamp_col: str,
+    feature_refs: List[str],
+    feature_views: List[FeatureView],
+    spark_session: SparkSession,
+    table_name: str,
+    registry: Registry,
+    project: str,
+) -> List[FeatureViewQueryContext]:
+    # interface of offline_utils.get_feature_view_query_context changed in feast==0.17
+    arg_spec = inspect.getfullargspec(
+        func=offline_utils.get_feature_view_query_context
+    )
+    if "entity_df_timestamp_range" in arg_spec.args:
+        # for feast>=0.17
+        entity_df_timestamp_range = _get_entity_df_event_timestamp_range(
+            entity_df=entity_df,
+            entity_df_event_timestamp_col=entity_df_event_timestamp_col,
+            spark_session=spark_session,
+            table_name=table_name,
+        )
+        query_context = offline_utils.get_feature_view_query_context(
+            feature_refs=feature_refs,
+            feature_views=feature_views,
+            registry=registry,
+            project=project,
+            entity_df_timestamp_range=entity_df_timestamp_range,
+        )
+    else:
+        # for feast<0.17
+        query_context = offline_utils.get_feature_view_query_context(
+            feature_refs=feature_refs,
+            feature_views=feature_views,
+            registry=registry,
+            project=project,
+        )
+    return query_context
 
 
 MULTIPLE_FEATURE_VIEW_POINT_IN_TIME_JOIN = """/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires = ["setuptools>=46.1.0", "setuptools_scm[toml]>=5", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ DEV_REQUIRES = INSTALL_REQUIRES + [
 
 setup(
     name="feast_spark_offline_store",
-    version="0.0.4",
     author="Thijs Brits",
+    use_version_scm=True,
     description="Spark support for Feast offline store",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
@@ -33,4 +33,5 @@ setup(
     packages=find_packages(include=["feast_spark_offline_store"]),
     install_requires=INSTALL_REQUIRES,
     extras_require={"dev": DEV_REQUIRES},
+    setup_requires=['setuptools_scm'],
 )

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setup(
     packages=find_packages(include=["feast_spark_offline_store"]),
     install_requires=INSTALL_REQUIRES,
     extras_require={"dev": DEV_REQUIRES},
-    setup_requires=['setuptools_scm'],
+    setup_requires=["setuptools_scm"],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+from distutils.dir_util import copy_tree
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import pytest
+from feast import FeatureStore
+
+ROOT = (Path(__file__).parent / "..").resolve()
+EXAMPLE_REPO_PATH = ROOT / "example_feature_repo"
+
+
+@pytest.fixture(scope="function")
+def feature_store() -> FeatureStore:
+    """Creates a feature store object whose data is cleaned up automatically"""
+    with TemporaryDirectory(dir=ROOT) as tmp_dir:
+        copy_tree(src=EXAMPLE_REPO_PATH, dst=tmp_dir)
+        yield FeatureStore(repo_path=tmp_dir)

--- a/tests/test_spark_offline_store.py
+++ b/tests/test_spark_offline_store.py
@@ -4,7 +4,12 @@ from datetime import datetime
 
 from feast import FeatureStore
 
-from example_feature_repo.example import driver, driver_hourly_stats_view, customer, customer_daily_profile_view
+from example_feature_repo.example import (
+    driver,
+    driver_hourly_stats_view,
+    customer,
+    customer_daily_profile_view,
+)
 
 
 def test_end_to_end_one_feature_view():
@@ -41,20 +46,29 @@ def test_end_to_end_multiple_feature_views():
 
     try:
         # apply repository
-        fs.apply([driver, driver_hourly_stats_view, customer, customer_daily_profile_view])
+        fs.apply(
+            [driver, driver_hourly_stats_view, customer, customer_daily_profile_view]
+        )
 
         # load data into online store (uses offline stores pull_latest_from_table_or_query)
         fs.materialize_incremental(end_date=datetime.now())
 
         entity_df = pd.DataFrame(
-            {"driver_id": [1001], "customer_id": [201], "event_timestamp": [datetime.now()]}
+            {
+                "driver_id": [1001],
+                "customer_id": [201],
+                "event_timestamp": [datetime.now()],
+            }
         )
 
         # Read features from offline store
         feature_vector = (
             fs.get_historical_features(
-                features=["driver_hourly_stats:conv_rate", "customer_daily_profile:lifetime_trip_count"],
-                entity_df=entity_df
+                features=[
+                    "driver_hourly_stats:conv_rate",
+                    "customer_daily_profile:lifetime_trip_count",
+                ],
+                entity_df=entity_df,
             )
             .to_df()
             .to_dict()

--- a/tests/test_spark_offline_store.py
+++ b/tests/test_spark_offline_store.py
@@ -85,10 +85,11 @@ def test_cli(feature_store: FeatureStore):
     os.system(f"PYTHONPATH=$PYTHONPATH:/$(pwd) feast -c {repo_name} apply")
     try:
         os.system(
-            f"PYTHONPATH=$PYTHONPATH:/$(pwd) feast -c {repo_name} materialize-incremental 2021-08-19T22:29:28 > output"
+            f"PYTHONPATH=$PYTHONPATH:/$(pwd) feast -c {repo_name} "
+            f"materialize-incremental 2021-08-19T22:29:28 > {repo_name}/output"
         )
 
-        with open("output", "r") as f:
+        with open(f"{repo_name}/output", "r") as f:
             output = f.read()
 
         if "Pulling latest features from spark offline store" not in output:


### PR DESCRIPTION
<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
- Extended `SparkOfflineStore` functionality to work with `feast>=0.17`
- Migrated to `setuptools_scm` for versioning
- Updated tests to make them runnable in parallel
- Reformatted code a bit (mostly imports and using kwargs in more places)
- PR also includes changes from upstream `main` that were not included in upstream `develop`

## Tested scenarios
Ran all tests

## Fixed issue
#14 